### PR TITLE
default to root user for scripts

### DIFF
--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -64,7 +64,7 @@ ADD scripts /tmp/scripts
 {% if script.user %}
 USER {{ script.user }}
 {% else %}
-USER jboss
+USER root
 {% endif %}
 RUN [ "bash", "-x", "/tmp/scripts/{{ script.package }}/{{ script.exec }}" ]
 


### PR DESCRIPTION
Change the default user for executing scripts to root from jboss.

I've just gone through our images and the vast majority of the time we are specifying root as the user (I counted 31 times and 7 when we did not specify a user) so we should make the default match the most common use case.

The other advantage is this is a better value for non-jboss uses making dogen more generic.