### PR TITLE
run 'run' in script package by default

### DIFF
--- a/docs/conventions.adoc
+++ b/docs/conventions.adoc
@@ -26,3 +26,10 @@ part of some package and install them manually.
 3. There should be *only one* repository per file.
 4. Only added repositories will be enabled during install of packages, all other repositories (including default)
    will be *disabled*.
+
+## Running scripts
+
+### Default script name
+
+If you do not specify an `exec` key for a script, dogen will check for a script named `run`
+and execute it if it exists.

--- a/docs/conventions.adoc
+++ b/docs/conventions.adoc
@@ -33,3 +33,7 @@ part of some package and install them manually.
 
 If you do not specify an `exec` key for a script, dogen will check for a script named `run`
 and execute it if it exists.
+
+### Default script execution user
+
+Dogen will execute all scripts as `root` unless you have specified a user with the `user` key.

--- a/dogen/__init__.py
+++ b/dogen/__init__.py
@@ -1,3 +1,7 @@
 from dogen.version import version
 
 __version__ = version
+
+# Script that is executed in a script package if it exists and if
+# no "exec" is explicitly defined
+DEFAULT_SCRIPT_EXEC = "run"

--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -13,7 +13,7 @@ from jinja2 import FileSystemLoader, Environment
 from dogen.git import Git
 from dogen.template_helper import TemplateHelper
 from dogen.tools import Tools
-from dogen.version import version
+from dogen import version, DEFAULT_SCRIPT_EXEC
 from dogen.errors import Error
 
 class Generator(object):
@@ -134,14 +134,18 @@ class Generator(object):
                 raise Error("Provided scripts directory '%s' does not exists" % self.scripts)
 
     def _handle_scripts(self):
-        for scripts in self.cfg['scripts']:
-            package = scripts['package']
+        for script in self.cfg['scripts']:
+            package = script['package']
+            src_path = os.path.join(self.scripts, package)
             output_path = os.path.join(self.output, "scripts", package)
+
+            if "exec" not in script and os.path.exists(os.path.join(src_path, DEFAULT_SCRIPT_EXEC)):
+                script['exec'] = DEFAULT_SCRIPT_EXEC
 
             # Poor-man's workaround for not copying multiple times the same thing
             if not os.path.exists(output_path):
                 self.log.info("Copying package '%s'..." % package)
-                shutil.copytree(src=os.path.join(self.scripts, package), dst=output_path)
+                shutil.copytree(src=src_path, dst=output_path)
                 self.log.debug("Done.")
 
     def _handle_additional_scripts(self):

--- a/tests/test_unit_generate_configuration.py
+++ b/tests/test_unit_generate_configuration.py
@@ -129,7 +129,7 @@ class TestConfig(unittest.TestCase):
         generator.configure()
         self.assertEqual(generator.additional_scripts, ["http://host/somescript"])
 
-    def test_custom_additional_scipts_in_cli_should_override_in_descriptor(self):
+    def test_custom_additional_scripts_in_cli_should_override_in_descriptor(self):
         with self.descriptor as f:
             f.write("dogen:\n  additional_scripts:\n    - http://host/somescript".encode())
 

--- a/tests/test_unit_generate_configuration.py
+++ b/tests/test_unit_generate_configuration.py
@@ -7,7 +7,7 @@ import tempfile
 
 from dogen.generator import Generator
 from dogen.errors import Error
-from dogen.version import version
+from dogen import version, DEFAULT_SCRIPT_EXEC
 
 class TestConfig(unittest.TestCase):
     def setUp(self):
@@ -136,3 +136,29 @@ class TestConfig(unittest.TestCase):
         generator = Generator(self.log, self.descriptor.name, "target", additional_scripts=["https://otherhost/otherscript"])
         generator.configure()
         self.assertEqual(generator.additional_scripts, ["https://otherhost/otherscript"])
+
+    @mock.patch('dogen.generator.os.path.exists', return_value=True)
+    def test_default_script_exec(self, mock_patch):
+        """Ensure that when no 'exec' is defined for a script, the default is used."""
+        with self.descriptor as f:
+            f.write("scripts:\n    - package: somepackage".encode())
+
+        generator = Generator(self.log, self.descriptor.name, "target", scripts="scripts")
+        generator.configure()
+        generator._handle_scripts()
+        self.assertEqual(generator.cfg['scripts'][0]['exec'], DEFAULT_SCRIPT_EXEC)
+
+    @mock.patch('dogen.generator.os.path.exists', return_value=True)
+    def test_custom_script_exec(self, mock_patch):
+        """Ensure that when 'exec' *is* defined for a script, it is used in place of the default."""
+
+        custom_script_name = "somescript.sh"
+        self.assertNotEqual(custom_script_name, DEFAULT_SCRIPT_EXEC)
+
+        with self.descriptor as f:
+            f.write(("scripts:\n  - package: somepackage\n    exec: " + custom_script_name).encode())
+
+        generator = Generator(self.log, self.descriptor.name, "target", scripts="scripts")
+        generator.configure()
+        generator._handle_scripts()
+        self.assertEqual(generator.cfg['scripts'][0]['exec'], custom_script_name)


### PR DESCRIPTION
By convention, if a script "configure" (module constant
DEFAULT_SCRIPT_EXEC) exists within a script package and
if the JSON file does not define another script to 'exec',
execute the default script.

"configure" was chosen, rather than "configure.sh", to not
rule out non-bourne shell scripts (although the code paths
still pass the result to bash -x, that could be changed in
future to allow for Python scripts, or whatever.)