### PR TITLE
Refactor how default script user is defined

### DIFF
--- a/docs/conventions.adoc
+++ b/docs/conventions.adoc
@@ -31,9 +31,16 @@ part of some package and install them manually.
 
 ### Default script name
 
-If you do not specify an `exec` key for a script, dogen will check for a script named `run`
-and execute it if it exists.
+If you specify an `exec` key for a script, that value will be used as the command name to be executed for a script.
+
+Otherwise, if the environment has `DOGEN_SCRIPT_EXEC` defined and a script with that name exists, it will be used.
+
+Otherwise, if a script with the name `run` exists, it will be execute if it exists.
 
 ### Default script execution user
 
-Dogen will execute all scripts as `root` unless you have specified a user with the `user` key.
+If you specify an `user` key for a script, that value will be used as the `USER` for executing the script.
+
+Otherwise, if the environment has `DOGEN_SCRIPT_USER` defined, it will be used as the `USER`.
+
+Otherwise, dogen will use `root`.

--- a/dogen/__init__.py
+++ b/dogen/__init__.py
@@ -5,3 +5,5 @@ __version__ = version
 # Script that is executed in a script package if it exists and if
 # no "exec" is explicitly defined
 DEFAULT_SCRIPT_EXEC = "run"
+# User used for executing scripts if no "user" is explicitly defined
+DEFAULT_SCRIPT_USER = "root"

--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -13,7 +13,7 @@ from jinja2 import FileSystemLoader, Environment
 from dogen.git import Git
 from dogen.template_helper import TemplateHelper
 from dogen.tools import Tools
-from dogen import version, DEFAULT_SCRIPT_EXEC
+from dogen import version, DEFAULT_SCRIPT_EXEC, DEFAULT_SCRIPT_USER
 from dogen.errors import Error
 
 class Generator(object):
@@ -141,6 +141,9 @@ class Generator(object):
 
             if "exec" not in script and os.path.exists(os.path.join(src_path, DEFAULT_SCRIPT_EXEC)):
                 script['exec'] = DEFAULT_SCRIPT_EXEC
+
+            if "user" not in script:
+                script['user'] = DEFAULT_SCRIPT_USER
 
             # Poor-man's workaround for not copying multiple times the same thing
             if not os.path.exists(output_path):

--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -139,11 +139,12 @@ class Generator(object):
             src_path = os.path.join(self.scripts, package)
             output_path = os.path.join(self.output, "scripts", package)
 
-            if "exec" not in script and os.path.exists(os.path.join(src_path, DEFAULT_SCRIPT_EXEC)):
-                script['exec'] = DEFAULT_SCRIPT_EXEC
+            possible_exec = os.getenv('DOGEN_SCRIPT_EXEC', DEFAULT_SCRIPT_EXEC)
+            if "exec" not in script and os.path.exists(os.path.join(src_path, possible_exec)):
+                script['exec'] = possible_exec
 
             if "user" not in script:
-                script['user'] = DEFAULT_SCRIPT_USER
+                script['user'] = os.getenv('DOGEN_SCRIPT_USER', DEFAULT_SCRIPT_USER)
 
             # Poor-man's workaround for not copying multiple times the same thing
             if not os.path.exists(output_path):

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -88,11 +88,7 @@ ADD scripts /tmp/scripts
 
 # Custom scripts
 {% for script in scripts %}
-{% if script.user %}
 USER {{ script.user }}
-{% else %}
-USER root
-{% endif %}
 RUN [ "bash", "-x", "/tmp/scripts/{{ script.package }}/{{ script.exec }}" ]
 
 {% endfor %}


### PR DESCRIPTION
NOTE: Before merging this, can we discuss how the dogen user/image repository could override these hard-coded defaults? Are they expected to fork dogen and change their version, or support adding overrides in the YAML, or something else?

---

Do not hard-code the default script user in the jinja file, and remove
the branching check from there. Instead use the same method as for
default script name.

This means we can write tests for the default user. With the older
method, we would need to write out a Dockerfile and then parse it back
in for testing.