### PR TITLE
Test for no scripts defined in YAML

### DIFF
--- a/tests/test_unit_generate_configuration.py
+++ b/tests/test_unit_generate_configuration.py
@@ -245,3 +245,14 @@ class TestConfig(unittest.TestCase):
         cfg = "scripts:\n  - package: somepackage\n    user: " + custom_script_user
 
         self.helper_test_script_user(cfg, custom_script_user)
+
+    def test_no_scripts_defined(self):
+        "make sure _handle_scripts doesn't blow up when there are no scripts"
+
+        with self.descriptor as f:
+            f.write("name: somecfg\n".encode())
+
+        generator = Generator(self.log, self.descriptor.name, "target", scripts="scripts")
+        generator.configure()
+        generator._handle_scripts()
+        # success if no stack trace thrown


### PR DESCRIPTION
A test that would fail if f8cea0e193c40ff2fc2f741c9318f1a9fa5fa27d
had not been applied.