### PR TITLE
Provide a schema for configuration YAML

### DIFF
--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -195,6 +195,9 @@ class Generator(object):
         with open(schema_path, 'r') as fh:
             schema = yaml.safe_load(fh)
 
+        if schema == None:
+            raise Error("couldn't read a valid schema at %s" % schema_path)
+
         for plugin in self.plugins:
             plugin.extend_schema(schema)
 

--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -9,6 +9,8 @@ import yaml
 import tempfile
 
 from jinja2 import FileSystemLoader, Environment
+from pykwalify.core import Core
+from pykwalify.errors import SchemaError
 
 from dogen.template_helper import TemplateHelper
 from dogen.tools import Tools
@@ -80,10 +82,7 @@ class Generator(object):
         Some Dogen configuration values can be set in the YAML
         descriptor file using the 'dogen' section.
         """
-
-        # Fail early if descriptor file is not found
-        if not os.path.exists(self.descriptor):
-            raise Error("Descriptor file '%s' could not be found. Please make sure you specified correct path." % self.descriptor)
+        self._validate_cfg()
 
         if not self.scripts_path:
             # If scripts directory is not provided, see if there is a "scripts"
@@ -92,9 +91,6 @@ class Generator(object):
             scripts = os.path.join(os.path.dirname(self.descriptor), "scripts")
             if os.path.exists(scripts) and os.path.isdir(scripts):
                 self.scripts_path = scripts
-
-        with open(self.descriptor, 'r') as stream:
-            self.cfg = yaml.safe_load(stream)
 
         dogen_cfg = self.cfg.get('dogen')
 
@@ -185,7 +181,34 @@ class Generator(object):
         for f in repo_files:
             self.cfg['additional_repos'].append(os.path.splitext(os.path.basename(f))[0])
 
+    def _validate_cfg(self):
+        """
+        Open and parse the YAML configuration file and ensure it matches
+        our Schema for a Dogen configuration.
+        """
+        # Fail early if descriptor file is not found
+        if not os.path.exists(self.descriptor):
+            raise Error("Descriptor file '%s' could not be found. Please make sure you specified correct path." % self.descriptor)
+
+        schema_path = os.path.join(self.pwd, "schema", "kwalify_schema.yaml")
+        schema = {}
+        with open(schema_path, 'r') as fh:
+            schema = yaml.safe_load(fh)
+
+        for plugin in self.plugins:
+            plugin.extend_schema(schema)
+
+        with open(self.descriptor, 'r') as stream:
+            self.cfg = yaml.safe_load(stream)
+
+        c = Core(source_data=self.cfg, schema_data=schema)
+        try:
+            c.validate(raise_exception=True)
+        except SchemaError as e:
+            raise Error(e)
+
     def run(self):
+
         # Set Dogen settings if  provided in descriptor
         self.configure()
 

--- a/dogen/plugin.py
+++ b/dogen/plugin.py
@@ -11,3 +11,11 @@ class Plugin(object):
 
     def after_sources(self, **kwargs):
         pass
+
+    def extend_schema(self, schema):
+        """
+        Plugins have an opportunity to extend the schema used to validate
+        the dogen YAML configuration, to support additional keys that the
+        plugin might need.
+        """
+        pass

--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -14,6 +14,18 @@ class CCT(Plugin):
     def __init__(self, dogen):
         super(CCT, self).__init__(dogen)
 
+    def extend_schema(self, parent_schema):
+        """
+        Read in a schema definition for our part of the config and hook it
+        into the parent schema at the cct: top-level key.
+        """
+        schema_path = os.path.join(self.dogen.pwd, "plugins", "cct", "cct_schema.yaml")
+        schema = {}
+        with open(schema_path, 'r') as fh:
+            schema = yaml.safe_load(fh)
+
+        parent_schema['map']['cct'] = schema
+
     def prepare(self, cfg):
         """
         create cct changes yaml file for image.yaml template decscriptor

--- a/dogen/plugins/cct/cct_schema.yaml
+++ b/dogen/plugins/cct/cct_schema.yaml
@@ -1,0 +1,14 @@
+# This is a Kwalify Schema, see http://pykwalify.readthedocs.io/ for more information
+map:
+  verbose: {type: int}
+  modules:
+    seq:
+      - map:
+          path: {type: str, required: True}
+  # We do not validate under the configure: key. This is passed to CCT
+  # which should either do its own validation or we should query CCT to
+  # obtain the schema for this section. There are some bugs in pykwalify
+  # which prevent us from doing slightly more here:
+  #                       https://github.com/Grokzen/pykwalify/issues/54
+  configure:
+    type: any

--- a/dogen/plugins/rpm.py
+++ b/dogen/plugins/rpm.py
@@ -13,6 +13,13 @@ class RPM(Plugin):
         super(RPM, self).__init__(dogen)
         self.rpms_directory = os.path.join(os.path.dirname(self.descriptor), "rpms")
 
+    def extend_schema(self, parent_schema):
+        """
+        Extend the Dogen configuration schema to have a top-level list of
+        strings at the 'rpms:' key
+        """
+        parent_schema['map']['rpms'] = {'seq':[{'type':'str'}],}
+
     def prepare(self, cfg):
         if not os.path.exists(self.rpms_directory):
             return

--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -1,0 +1,67 @@
+# This is a Kwalify Schema, see http://pykwalify.readthedocs.io/ for more information
+map:
+  name:    {type: str, required: True}
+  from:    {type: str, required: True}
+  version: {type: text, required: True}
+  release: {type: text, required: True}
+  description: {type: text}
+  cmd:
+    type: seq
+    sequence:
+      - type: str
+  openshift: {type: bool}
+  labels:
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name: {type: str, required: True}
+          value: {type: str, required: True}
+          description: {type: str}
+  envs:
+    type: map
+    mapping:
+      information:
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              name: {type: str, required: True}
+              value: {type: any, required: True}
+              description: {type: str}
+      configuration:
+        seq:
+          - map:
+              name: {type: str, required: True}
+              example: {type: any}
+              description: {type: str}
+  ports:
+    seq:
+      - map:
+          value: {type: int, required: True}
+  debugport: {type: int}
+  dogen:
+    map:
+      version: {type: text}
+      ssl_verify: {type: bool}
+      template: {type: str}
+      scripts_path: {type: str}
+      additional_scripts:
+        seq:
+          - {type: str}
+  scripts:
+    seq:
+      - map:
+         package: {type: str}
+         exec: {type: str}
+         user: {type: text}
+  verbose: {type: int}
+  maintainer: {type: str}
+  sources:
+    seq:
+      - map:
+          url: {type: str}
+          hash: {type: str}
+  packages:
+    seq:
+      - {type: str}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==3.11
 Jinja2==2.8
 requests==2.8.1
 six==1.10.0
+pykwalify>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ setup(
     version = version,
     packages = find_packages(exclude=["tests"]),
     package_data = {
-        'dogen.templates': ['*.jinja']
+        'dogen.templates': ['*.jinja'],
+        'dogen.schema': ['*.yaml'],
+        'dogen.plugins.cct': ['*.yaml'],
     },
     url = 'https://github.com/jboss-dockerfiles/dogen',
     download_url = "https://github.com/jboss-dockerfiles/dogen/archive/%s.tar.gz" % version,

--- a/tests/schemas/bad/missing_from.yaml
+++ b/tests/schemas/bad/missing_from.yaml
@@ -1,0 +1,6 @@
+release: '1'
+version: '1'
+cmd:
+ - whoami
+#from: scratch
+name: someimage

--- a/tests/schemas/bad/missing_name.yaml
+++ b/tests/schemas/bad/missing_name.yaml
@@ -1,0 +1,6 @@
+release: '1'
+version: '1'
+cmd:
+ - whoami
+from: scratch
+#name: someimage

--- a/tests/schemas/bad/missing_release.yaml
+++ b/tests/schemas/bad/missing_release.yaml
@@ -1,0 +1,6 @@
+#release: '1'
+version: '1'
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/bad/missing_version.yaml
+++ b/tests/schemas/bad/missing_version.yaml
@@ -1,0 +1,6 @@
+release: '1'
+#version: '1'
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/good/empty_cmd.yaml
+++ b/tests/schemas/good/empty_cmd.yaml
@@ -1,0 +1,6 @@
+# The minimal permitted configuration
+release: '1'
+version: '1'
+cmd: []
+from: scratch
+name: someimage

--- a/tests/schemas/good/minimal.yaml
+++ b/tests/schemas/good/minimal.yaml
@@ -1,0 +1,7 @@
+# The minimal permitted configuration
+release: '1'
+version: '1'
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/good/missing_cmd.yaml
+++ b/tests/schemas/good/missing_cmd.yaml
@@ -1,0 +1,6 @@
+release: '1'
+version: '1'
+#cmd:
+# - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/good/numeric_release.yaml
+++ b/tests/schemas/good/numeric_release.yaml
@@ -1,0 +1,7 @@
+# Ensure that numeric release is permitted
+release: 1
+version: '1'
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/good/numeric_version.yaml
+++ b/tests/schemas/good/numeric_version.yaml
@@ -1,0 +1,7 @@
+# Ensure that numeric version is permitted
+release: '1'
+version: 1
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,35 @@
+import unittest
+import mock
+import os
+import glob
+
+from dogen.generator import Generator
+from dogen.errors import Error
+
+class TestSchemaMeta(type):
+    def __new__(mcls, name, bases, dict):
+        def gen_test(path, good):
+            def test(self):
+                generator = Generator(self.log, path, "target")
+                if good:
+                    generator.configure()
+                else:
+                    with self.assertRaises(Error):
+                        generator.configure()
+            return test
+
+        for test in glob.glob(os.path.join(os.path.dirname(__file__), "schemas", "good", "*yaml")):
+            test_name = "test_%s_is_valid" % os.path.splitext(os.path.basename(test))[0]
+            dict[test_name] = gen_test(test, good=True)
+
+        for test in glob.glob(os.path.join(os.path.dirname(__file__), "schemas", "bad", "*yaml")):
+            test_name = "test_%s_not_valid" % os.path.splitext(os.path.basename(test))[0]
+            dict[test_name] = gen_test(test, good=False)
+
+        return type.__new__(mcls, name, bases, dict)
+
+class TestSchema(unittest.TestCase):
+    __metaclass__ = TestSchemaMeta
+
+    def setUp(self):
+        self.log = mock.Mock()

--- a/tests/test_unit_generate.py
+++ b/tests/test_unit_generate.py
@@ -6,11 +6,17 @@ import os
 from dogen.generator import Generator
 
 class TestGenerateCustomRepoFiles(unittest.TestCase):
+
+    # keys that must be present in config file but we don't care about
+    # for specific tests
+    basic_config ="release: '1'\nversion: '1'\ncmd:\n - whoami\nfrom: scratch\nname: someimage\n"
+
     def setUp(self):
         self.log = mock.Mock()
         self.descriptor = tempfile.NamedTemporaryFile(delete=False)
 
         with self.descriptor as f:
+            f.write(self.basic_config.encode())
             f.write("dogen:\n  ssl_verify: true".encode())
 
         self.generator = Generator(self.log, self.descriptor.name, "target")


### PR DESCRIPTION
Bundle a schema (Kwalify format) for the dogen configuration YAML
and use it to validate user supplied dogen configuration at run
time.

Add an extend_schema hook for plugins to adjust the schema to
reflect additional configuration the expect before the validation
runs.

Adjust the cct plugin to extend the schema with {cct: any}. This
means the cct key can be present, and anything under it; we will
let cct itself validate the sub-tree.