### PR TITLE
cct: permit specification of module name

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -38,7 +38,9 @@ class CCT(Plugin):
     def _prepare_modules(self, cfg):
         for module in cfg['cct']['modules']:
             name = None
-            if module['path'][-1] == '/':
+            if 'name' in module:
+                name = module['name']
+            elif module['path'][-1] == '/':
                 name = os.path.basename(module['path'][0:-1])
             elif len(module['path']) > 4 and module['path'][-4:] == ".git":
                 name = os.path.basename(module['path'][0:-4])


### PR DESCRIPTION
Allow the user to specify the name for a given CCT module directly
rather than relying on inferring it from the path. Continue to use
the path if a name is not explicitly provided.

Example: as before, name 'base' inferred from path

    cct:
        modules:
          - path: "https://github.com/containers-tools/base.git"

Example: new, now user explicitly defines 'standalone-amq':

    cct:
        modules:
          - path: "https://github.com/jmtd/tmp-standalone-amq.git'
            name: 'standalone-amq'