### PR TITLE
cct plugin: support for runtime changes

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -47,6 +47,9 @@ class CCT(Plugin):
         with open(cfg_file, 'w') as f:
             yaml.dump(cfg['cct']['configure'], f)
 
+        if 'runtime' in cfg['cct']:
+            self.runtime_changes(cfg)
+
     def _prepare_modules(self, cfg):
         for module in cfg['cct']['modules']:
             name = None
@@ -111,4 +114,24 @@ class CCT(Plugin):
             cfg['sources'].extend(dogen_sources)
         except:
             cfg['sources'] = dogen_sources
+
+    def runtime_changes(self, cfg):
+        """
+        Handle configuring CCT for runtime use.
+
+        User may supply a /cct/runtime key which will be written out as
+        instructions for cct to execute at runtime.
+        """
+
+        # write out a cctruntime.yaml file from the /cct/runtime_changes key
+        cfg_file_dir = os.path.join(self.output, "cct")
+        if not os.path.exists(cfg_file_dir):
+            os.makedirs(cfg_file_dir)
+        cfg_file = os.path.join(cfg_file_dir, "cctruntime.yaml")
+        with open(cfg_file, 'w') as f:
+            yaml.dump(cfg['cct']['runtime'], f)
+
+        # adjust cfg object so template adds the above to ENTRYPOINT
+        if not 'runtime_changes' in cfg['cct']:
+            cfg['cct']['runtime_changes'] = "/tmp/cct/cctruntime.yaml"
 

--- a/dogen/plugins/cct/cct_schema.yaml
+++ b/dogen/plugins/cct/cct_schema.yaml
@@ -12,3 +12,6 @@ map:
   #                       https://github.com/Grokzen/pykwalify/issues/54
   configure:
     type: any
+  runtime_changes: { type: str }
+  # same rationale as for configure
+  runtime: { type: any }

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -101,11 +101,12 @@ RUN [ "bash", "-x", "/tmp/scripts/{{ script.package }}/{{ script.exec }}" ]
 # Run cct if needed
 {% if cct %}
 ADD cct /tmp/cct/
-RUN CCT_MODULES_PATH=/tmp/cct/ cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
+ENV CCT_MODULES_PATH=/tmp/cct/
+RUN cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
 
 # Add cct in command mode as entrypoint
-# you can specify path to changes files in CCT_CHANGES environemnt variable
-ENTRYPOINT ["/usr/bin/cct", "-c"]
+# you can specify path to changes files in CCT_CHANGES environment variable
+ENTRYPOINT ["/usr/bin/cct", {% if cct.runtime_changes -%}"{{ cct.runtime_changes }}", {% endif -%}"-c"]
 {% endif %}
 
 {%- if scripts %}


### PR DESCRIPTION
Add support to the cct plugin for runtime changes.

Adjust the template so that we set the CCT_MODULES_PATH environment
variable via Dockerfile ENV. This is then honoured by both the build
time and run time cct invocations.

Adjust the template so that any values in the list cct.runtime_changes
are added into the ENTRYPOINT command.

Extend the cct plugin so that a /cct/runtime key in the dogen YAML
is written out to a file cctruntime.yaml and cct.runtime_changes is
set so that it is included in the ENTRYPOINT command (using the scheme
described above)