### PR TITLE
un-rename cct key for checksum

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -108,7 +108,7 @@ class CCT(Plugin):
         for source in cct_sources:
             dogen_source = {}
             dogen_source['url'] = source_prefix + source['name']
-            dogen_source['md5sum'] = source['md5sum']
+            dogen_source['md5sum'] = source['chksum']
             dogen_sources.append(dogen_source)
         try:
             cfg['sources'].extend(dogen_sources)


### PR DESCRIPTION
We changed dogen to use md5sum: as the key value for md5sums, but
we haven't (yet) changed cct. Therefore, adjust cct module to continue
to look for the (old/existing) key value 'chksum'.