### PR TITLE
Revert "un-rename cct key for checksum"

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -108,7 +108,7 @@ class CCT(Plugin):
         for source in cct_sources:
             dogen_source = {}
             dogen_source['url'] = source_prefix + source['name']
-            dogen_source['md5sum'] = source['chksum']
+            dogen_source['md5sum'] = source['md5sum']
             dogen_sources.append(dogen_source)
         try:
             cfg['sources'].extend(dogen_sources)


### PR DESCRIPTION
This reverts commit e18aec7832153600077702a4d9d340786c551e4c.

I've just modified cct to use md5sum so it's consistent everywhere.