### PR TITLE
Define default user for cct, permit override

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -19,7 +19,7 @@ class CCT(Plugin):
         Read in a schema definition for our part of the config and hook it
         into the parent schema at the cct: top-level key.
         """
-        schema_path = os.path.join(self.dogen.pwd, "plugins", "cct", "cct_schema.yaml")
+        schema_path = os.path.join(self.dogen.pwd, "schema", "cct_schema.yaml")
         schema = {}
         with open(schema_path, 'r') as fh:
             schema = yaml.safe_load(fh)
@@ -49,6 +49,9 @@ class CCT(Plugin):
 
         if 'runtime' in cfg['cct']:
             self.runtime_changes(cfg)
+
+        if not 'user' in cfg['cct']:
+            cfg['cct']['user'] = 'root'
 
     def _prepare_modules(self, cfg):
         for module in cfg['cct']['modules']:

--- a/dogen/schema/cct_schema.yaml
+++ b/dogen/schema/cct_schema.yaml
@@ -15,3 +15,4 @@ map:
   runtime_changes: { type: str }
   # same rationale as for configure
   runtime: { type: any }
+  user: { type: any }

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -102,6 +102,7 @@ RUN [ "bash", "-x", "/tmp/scripts/{{ script.package }}/{{ script.exec }}" ]
 {% if cct %}
 ADD cct /tmp/cct/
 ENV CCT_MODULES_PATH=/tmp/cct/
+USER {{ cct.user }}
 RUN cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
 
 # Add cct in command mode as entrypoint

--- a/tests/test_cct_plugin.py
+++ b/tests/test_cct_plugin.py
@@ -1,0 +1,26 @@
+import tempfile
+import unittest
+import shutil
+
+from dogen.plugins import cct
+
+# minimal fake dogen object
+class MockDogen():
+    def __init__(self):
+        self.log = 0
+        self.descriptor = 0
+        self.output = ""
+
+class TestCCTPlugin(unittest.TestCase):
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='test_cct_plugin')
+        self.cct = cct.CCT(dogen=MockDogen())
+
+    def teardown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_default_user_root(self):
+        cfg = { 'cct': { 'configure': '' }}
+        self.cct.prepare(cfg)
+        self.assertTrue('user' in cfg['cct'])
+        self.assertEqual(cfg['cct']['user'], "root")


### PR DESCRIPTION
Set an explicit default user for executing cct. Fixes #32.

Permit overriding the user via the YAML key cct.user.

Add a test.

As part of writing the test, re-arrange the cct plugin's schema
location. Put it adjacent to the main one. Delete
dogen/plugins/cct/__init__.py, which masked importing the cct plugin.

NOTE: if you have test failures, you may need to remove
dogen/plugins/cct/__init__.pyc manually.