### PR TITLE
Remove openshift key

### DIFF
--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -10,7 +10,6 @@ map:
     type: seq
     sequence:
       - type: str
-  openshift: {type: bool}
   labels:
     type: seq
     sequence:

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -116,13 +116,6 @@ USER root
 RUN rm -rf /tmp/scripts
 {% endif %}
 
-{%- if openshift %}
-# Switch to the user 185 for OpenShift usage
-USER 185
-{% else %}
-USER jboss
-{% endif %}
-
 {%- if workdir %}
 # Specify the working directory
 WORKDIR {{ workdir }}

--- a/tests/schemas/bad/openshift_key.yaml
+++ b/tests/schemas/bad/openshift_key.yaml
@@ -1,0 +1,8 @@
+# openshift key no longer supported
+release: '1'
+version: '1'
+openshift: true
+cmd:
+ - whoami
+from: scratch
+name: someimage

--- a/tests/schemas/good/openshift_amq_6.2_image.yaml
+++ b/tests/schemas/good/openshift_amq_6.2_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-amq-6/amq62-openshift"
 version: "1.4"
 release: "dev"
 from: "jboss-amq-6/amq62:1.2"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "A reliable messaging platform that supports standard messaging paradigms for a real-time enterprise."

--- a/tests/schemas/good/openshift_datagrid_6.5_image.yaml
+++ b/tests/schemas/good/openshift_datagrid_6.5_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-datagrid-6/datagrid65-openshift"
 version: "1.2"
 release: "dev"
 from: "jboss-datagrid-6/datagrid65"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Provides a scalable in-memory distributed database designed for fast access to large volumes of data."

--- a/tests/schemas/good/openshift_decisionserver_6.2_image.yaml
+++ b/tests/schemas/good/openshift_decisionserver_6.2_image.yaml
@@ -3,7 +3,6 @@ version: "1.3"
 release: "dev"
 from: "jboss-kieserver-6/kieserver62-openshift:1.3"
 description: "Platform for executing business rules on JBoss BRMS Realtime Decision Server 6.2."
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for executing business rules on JBoss BRMS Realtime Decision Server 6.2."

--- a/tests/schemas/good/openshift_decisionserver_6.3_image.yaml
+++ b/tests/schemas/good/openshift_decisionserver_6.3_image.yaml
@@ -3,7 +3,6 @@ version: "1.3"
 release: "dev"
 from: "jboss-kieserver-6/kieserver63-openshift:1.3"
 description: "Platform for executing business rules on JBoss BRMS Realtime Decision Server 6.3."
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for executing business rules on JBoss BRMS Realtime Decision Server 6.3."

--- a/tests/schemas/good/openshift_eap_6.4_image.yaml
+++ b/tests/schemas/good/openshift_eap_6.4_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-eap-6/eap64-openshift"
 version: "1.4"
 release: "dev"
 from: "jboss-eap-6/eap64:1.3"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for building and running JavaEE applications on JBoss EAP 6.4"

--- a/tests/schemas/good/openshift_eap_7.0_image.yaml
+++ b/tests/schemas/good/openshift_eap_7.0_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-eap-7/eap70-openshift"
 version: "1.4"
 release: "dev"
 from: "jboss-eap-7-tech-preview/eap70:1.2"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for building and running JavaEE applications on JBoss EAP 7.0"

--- a/tests/schemas/good/openshift_fuse-camel_6.3_image.yaml
+++ b/tests/schemas/good/openshift_fuse-camel_6.3_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-fuse-6/camel63-openshift"
 version: "1.0"
 release: "dev"
 from: "jboss-fuse-6/fuse63:1.0"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for building and running Apache Camel applications on EAP"

--- a/tests/schemas/good/openshift_kieserver_6.2_image.yaml
+++ b/tests/schemas/good/openshift_kieserver_6.2_image.yaml
@@ -3,7 +3,6 @@ version: "1.3"
 release: "dev"
 from: "jboss-eap-6/eap64-openshift"
 description: "Base image supporting `jboss-decisionserver-6/decisionserver62-openshift`. This is not currently released or supported as an independent image for end-users."
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Base platform for executing business rules and processes on JBoss BxMS KIE Server 6.2."

--- a/tests/schemas/good/openshift_kieserver_6.3_image.yaml
+++ b/tests/schemas/good/openshift_kieserver_6.3_image.yaml
@@ -3,7 +3,6 @@ version: "1.3"
 release: "dev"
 from: "jboss-eap-6/eap64-openshift:1.4"
 description: "Base image supporting `jboss-decisionserver-6/decisionserver63-openshift`. This is not currently released or supported as an independent image for end-users."
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Base platform for executing business rules and processes on JBoss BxMS KIE Server 6.3."

--- a/tests/schemas/good/openshift_processserver_6.3_image.yaml
+++ b/tests/schemas/good/openshift_processserver_6.3_image.yaml
@@ -3,7 +3,6 @@ version: "1.3"
 release: "dev"
 from: "jboss-kieserver-6/kieserver63-openshift:1.3"
 description: "Platform for executing business rules on JBoss BPMS Intelligent Process Server 6.3."
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for executing business rules on JBoss BPMS Intelligent Process Server 6.3."

--- a/tests/schemas/good/openshift_sso_7.0_image.yaml
+++ b/tests/schemas/good/openshift_sso_7.0_image.yaml
@@ -2,7 +2,6 @@ name: "redhat-sso-7/sso70-openshift"
 version: "1.3"
 release: "dev"
 from: "redhat-sso-7/sso70:1.4"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for running Red Hat SSO"

--- a/tests/schemas/good/openshift_webserver-tomcat7_3.0_image.yaml
+++ b/tests/schemas/good/openshift_webserver-tomcat7_3.0_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-webserver-3/webserver30-tomcat7-openshift"
 version: "1.2"
 release: "dev"
 from: "jboss-webserver-3/webserver30-tomcat7"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for building and running web applications on JBoss Web Server 3.0 - Tomcat v7"

--- a/tests/schemas/good/openshift_webserver-tomcat8_3.0_image.yaml
+++ b/tests/schemas/good/openshift_webserver-tomcat8_3.0_image.yaml
@@ -2,7 +2,6 @@ name: "jboss-webserver-3/webserver30-tomcat8-openshift"
 version: "1.2"
 release: "dev"
 from: "jboss-webserver-3/webserver30-tomcat8"
-openshift: true
 labels:
     - name: "io.k8s.description"
       value: "Platform for building and running web applications on JBoss Web Server 3.0 - Tomcat v8"


### PR DESCRIPTION
The openshift key in the schema was used to conditionally switch a
USER statement in the template prior to the CMD running. It switched
it between "USER jboss" (wildfly/community specific) and "USER 185"
(openshift/jboss specific).

The same can be achieved with the newer "user:" key, which is also
more generic and useful for not wildfly/community/jboss/openshift.