### PR TITLE
pass -v to ENTRYPOINT cct if verbose is on

### DIFF
--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -107,7 +107,7 @@ RUN cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ ru
 
 # Add cct in command mode as entrypoint
 # you can specify path to changes files in CCT_CHANGES environment variable
-ENTRYPOINT ["/usr/bin/cct", {% if cct.runtime_changes -%}"{{ cct.runtime_changes }}", {% endif -%}"-c"]
+ENTRYPOINT ["/usr/bin/cct", {%if cct.runtime_changes -%}"{{ cct.runtime_changes }}", {% endif -%}{%if cct.verbose %}"-v", {% endif %}"-c"]
 {% endif %}
 
 {%- if scripts %}


### PR DESCRIPTION
If cct.verbose is defined, pass -v to the ENTRYPOINT invocation of
cct as well as the build-time invocation.