### PR TITLE
fixed cct plugin to not die if there is no cct instruction in a descriptor

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -31,6 +31,11 @@ class CCT(Plugin):
         create cct changes yaml file for image.yaml template decscriptor
         it require cct aware template.jinja file
         """
+        # check if cct plugin has any steps to perform (prevent it from raising ugly exceptions)
+        if not 'cct' in cfg:
+            self.log.debug("No cct key in image.yaml - nothing to do")
+            return
+
         if os.path.exists(self.output + '/cct/'):
             shutil.rmtree(self.output + '/cct/')
 


### PR DESCRIPTION
this enables to have cct plugin enabled even for descriptor without cct sections
this is useful for converting images to cct - we have same dogen command for cct and cct descriptors