### PR TITLE
tweak cct schema to add name

### DIFF
--- a/dogen/schema/cct_schema.yaml
+++ b/dogen/schema/cct_schema.yaml
@@ -5,6 +5,7 @@ map:
     seq:
       - map:
           path: {type: str, required: True}
+          name: {type: str}
   # We do not validate under the configure: key. This is passed to CCT
   # which should either do its own validation or we should query CCT to
   # obtain the schema for this section. There are some bugs in pykwalify


### PR DESCRIPTION
We have a (currently undocumented) feature where a CCT module can
be defined in terms of a name only, and if a directory matching that
name exists in a 'cct' directory adjacent to the image.yaml we are
processing, it is used as the module source.

This feature did not work since the schema was introduced because
the schema defined the 'path' key as mandatory. This change relaxes
that and also defines the optional 'name' key that this feature
relies upon.