### PR TITLE
Add support for definining target name of the artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.5
 RUN apk add --update sudo bash py-setuptools git && rm -rf /var/cache/apk/*
 
 ENV DOGEN_VERSION master

--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -63,6 +63,7 @@ map:
       - map:
           url: {type: str}
           md5sum: {type: str}
+          target: {type: str}
   packages:
     seq:
       - {type: str}

--- a/tests/test_unit_generate_handle_files.py
+++ b/tests/test_unit_generate_handle_files.py
@@ -41,8 +41,8 @@ class TestFetchFile(unittest.TestCase):
             mock_requests.assert_called_with('https://host/file.tmp', verify=None)
             mock_file().write.assert_called_once_with("file-content")
 
-        self.log.debug.assert_any_call("Fetching 'https://host/file.tmp' file...")
-        self.log.debug.assert_any_call("Fetched file will be saved as 'some-file'...")
+        self.log.info.assert_any_call("Fetching 'https://host/file.tmp' file...")
+        self.log.info.assert_any_call("Fetched file will be saved as 'some-file'...")
 
 
     @mock.patch('dogen.generator.tempfile.mktemp', return_value="tmpfile")
@@ -56,8 +56,8 @@ class TestFetchFile(unittest.TestCase):
             mock_requests.assert_called_with('https://host/file.tmp', verify=None)
             mock_file().write.assert_called_once_with("file-content")
 
-        self.log.debug.assert_any_call("Fetching 'https://host/file.tmp' file...")
-        self.log.debug.assert_any_call("Fetched file will be saved as 'tmpfile'...")
+        self.log.info.assert_any_call("Fetching 'https://host/file.tmp' file...")
+        self.log.info.assert_any_call("Fetched file will be saved as 'tmpfile'...")
 
 class TestCustomTemplateHandling(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
If 'target' is defined, the downloaded file will be renamed
to the provided name.

Fixes #71