### PR TITLE
sort repo_files when generating additional_repos

### DIFF
--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -184,7 +184,7 @@ class Generator(object):
 
         self.log.debug("Found following additional repo files: %s" % ", ".join(repo_files))
 
-        for f in repo_files:
+        for f in sorted(repo_files):
             self.cfg['additional_repos'].append(os.path.splitext(os.path.basename(f))[0])
 
     def _validate_cfg(self):


### PR DESCRIPTION
The output of glob.glob is not deterministic. Therefore, multiple runs
of dogen on the same source might generate slightly different outputs.
One example is the ordering of the "yum install" and "rm ..."
instructions when using additional repos.

Lexographically sort the list of repo files before populating
additional_repos to make this part deterministic.