### PR TITLE
use lower-case string comparison for md5sum check

### DIFF
--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -306,6 +306,6 @@ class Generator(object):
     def check_sum(self, filename, checksum):
         self.log.info("Checking '%s' MD5 hash..." % os.path.basename(filename))
         filesum = hashlib.md5(open(filename, 'rb').read()).hexdigest()
-        if filesum != checksum:
+        if filesum.lower() != checksum.lower():
             raise Exception("The md5sum computed for the '%s' file ('%s') doesn't match the '%s' value" % (filename, filesum, checksum))
         self.log.debug("MD5 hash is correct.")


### PR DESCRIPTION
So e.g.  50e73f255f9bde50789ad5bd657c7a71 as computed would match a
value of 50E73F255F9BDE50789AD5BD657C7A71 in the YAML