### PR TITLE
move EXPOSE instructions towards end of template

### DIFF
--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -45,12 +45,6 @@ LABEL name="$JBOSS_IMAGE_NAME" \
       {% endfor %}
 {% endif %}
 
-{% if ports %}
-# Exposed ports
-EXPOSE {%- for port in ports %} {{ port.value }}{% endfor %}
-
-{% endif %}
-
 USER root
 
 {% if packages or rpms %}
@@ -118,6 +112,11 @@ RUN rm -rf /tmp/scripts
 {%- if artifacts %}
 USER root
 RUN rm -rf /tmp/artifacts
+{% endif %}
+
+{% if ports %}
+# Exposed ports
+EXPOSE {%- for port in ports %} {{ port.value }}{% endfor %}
 {% endif %}
 
 {%- if workdir %}


### PR DESCRIPTION
EXPOSE instructions do not take effect during build time, so it doesn't
matter where they are in the Dockerfile. However, putting them early in
the template means that if the user changes ports, all instructions
after EXPOSE are invalided in Docker's build cache.

Move it towards the end so a user can change ports in their image.yaml,
regenerate to an existing build directory and rebuild without
invalidating (possibly expensive) instructions.

We could do the same for LABELs, but not ENVs (which might be depended
upon by scripts run at build-time), and it's probably a good idea to
keep the LABELs and ENVs together.