### PR TITLE
Remove debugport key

### DIFF
--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -43,10 +43,11 @@ map:
     seq:
       - map:
           value: {type: int, required: True}
+          expose: {type: bool}
+          description: {type: str}
   volumes:
       seq:
         - {type: str, required: True}
-  debugport: {type: int}
   dogen:
     map:
       version: {type: text}

--- a/dogen/template_helper.py
+++ b/dogen/template_helper.py
@@ -63,3 +63,17 @@ class TemplateHelper(object):
 
         return envs
 
+    def ports(self, available_ports):
+        """
+        Combines all ports that should be added to the
+        Dockerfile into one array
+        """
+
+        port_list = []
+
+        for p in available_ports:
+            if p.get('expose', True):
+                port_list.append(p.get('value'))
+
+        return port_list
+

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -45,7 +45,7 @@ LABEL name="$JBOSS_IMAGE_NAME" \
 
 {% if ports %}
 # Exposed ports
-EXPOSE {%- for port in ports %} {{ port.value }}{% endfor %}
+EXPOSE {%- for port in helper.ports(ports) %} {{ port }}{% endfor %}
 
 {% endif %}
 

--- a/tests/schemas/good/debugport.yaml
+++ b/tests/schemas/good/debugport.yaml
@@ -1,0 +1,13 @@
+# The minimal permitted configuration
+release: '1'
+version: '1'
+cmd:
+ - whoami
+from: scratch
+name: someimage
+ports:
+  - value: 8080
+    description: "This is default port"
+  - value: 9999
+    description: "This is debug port port"
+    expose: False

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -128,3 +128,22 @@ class TestDockerfile(unittest.TestCase):
             dockerfile = f.read()
             regex = re.compile(r'.*VOLUME \["/var/lib"\]\nVOLUME \["/usr/lib"\]',  re.MULTILINE)
             self.assertRegexpMatches(dockerfile, regex)
+
+    # https://github.com/jboss-dockerfiles/dogen/issues/124
+    def test_debug_port(self):
+        """
+        Test that cmd: is mapped into a CMD instruction
+        """
+        with open(self.yaml, 'ab') as f:
+            f.write("ports:\n  - value: 8080\n  - value: 9999\n    expose: False".encode())
+
+        generator = Generator(self.log, self.args)
+        generator.configure()
+        generator.render_from_template()
+
+        self.assertEqual(generator.cfg['ports'], [{'value': 8080}, {'expose': False, 'value': 9999}])
+
+        with open(os.path.join(self.target, "Dockerfile"), "r") as f:
+            dockerfile = f.read()
+            regex = re.compile(r'.*EXPOSE 8080$',  re.MULTILINE)
+            self.assertRegexpMatches(dockerfile, regex)


### PR DESCRIPTION
Instead it should be listed in the regular ports section with
a 'expose' set to False.

Fixes #124