### PR TITLE
Generate maintainer label based on maintainer key

### DIFF
--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -226,6 +226,15 @@ class Generator(object):
         self.log.info("Finished!")
 
     def render_from_template(self):
+        maintainer = self.cfg.get('maintainer')
+
+        # https://github.com/jboss-dockerfiles/dogen/issues/129
+        if maintainer:
+            if not self.cfg.get('labels'):
+                self.cfg['labels'] = []
+
+            self.cfg['labels'].append({'name': 'maintainer', 'value': maintainer})
+
         if self.template:
             template_file = self.template
         else:

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -18,11 +18,6 @@
 
 FROM {{ helper.base_image(from, version) }}
 
-{% if maintainer %}
-MAINTAINER {{ maintainer }}
-
-{% endif -%}
-
 # Environment variables
 ENV JBOSS_IMAGE_NAME="{{name}}" \
     JBOSS_IMAGE_VERSION="{{version}}" {% if helper.envs(envs) %}\{% for env in helper.envs(envs) %}


### PR DESCRIPTION
Image author should add from now on the 'maintainer' label:
https://docs.docker.com/engine/reference/builder/#label

Fixes #129