### PR TITLE
Remove verbose key from schema

### DIFF
--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -60,7 +60,6 @@ map:
          package: {type: str}
          exec: {type: str}
          user: {type: text}
-  verbose: {type: int}
   maintainer: {type: str}
   workdir: {type: str}
   sources:


### PR DESCRIPTION
It was unused, besides this it's a CLI option.

Fixes #128.