### PR TITLE
Fixes multiple issues with downloading artifacts

### DIFF
--- a/dogen/cli.py
+++ b/dogen/cli.py
@@ -14,6 +14,7 @@ from dogen.version import version
 from dogen.errors import Error
 from dogen.plugin import Plugin
 
+import colorlog
 
 class MyParser(argparse.ArgumentParser):
 
@@ -25,14 +26,15 @@ class MyParser(argparse.ArgumentParser):
 class CLI(object):
 
     def __init__(self):
-        self.log = logging.getLogger("dogen")
+        formatter = colorlog.ColoredFormatter(
+            '%(log_color)s%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler = logging.StreamHandler()
-        formatter = logging.Formatter(
-            '%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
+
+        self.log = logging.getLogger("dogen")
         self.log.addHandler(handler)
 
-        for package in ["requests.packages.urllib3", "pykwalify.core", "pykwalify.rule"]:
+        for package in ["requests.packages.urllib3", "pykwalify.rule"]:
             log = logging.getLogger(package)
             log.setLevel(logging.INFO)
 
@@ -86,7 +88,10 @@ class CLI(object):
         except KeyboardInterrupt as e:
             pass
         except Error as e:
-            self.log.exception(e)
+            if args.verbose:
+                self.log.exception(e)
+            else:
+                self.log.error(str(e))
             sys.exit(1)
 
     def get_plugins(self):

--- a/dogen/schema/kwalify_schema.yaml
+++ b/dogen/schema/kwalify_schema.yaml
@@ -64,6 +64,7 @@ map:
           sha1: {type: str}
           sha256: {type: str}
           target: {type: str}
+          hint: {type: str}
   packages:
     seq:
       - {type: str}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Jinja2>=2.8
 requests>=2.8.1
 six>=1.10.0
 pykwalify>=1.5.1
+colorlog>=2.10.0


### PR DESCRIPTION
1. Adds a way to specify a hint for artifacts - it can be used to
   let the user know where to find the artifact if it's not publicly available
2. When an artifact was not found in the cache - try to fetch it from
   original location.

Additionally a color output was added to logging for easier reading.

Fixes #142, #131, #130