### PR TITLE
enabled to use CCT modules from cct dir next to the image descriptor

### DIFF
--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -91,6 +91,14 @@ class CCT(Plugin):
 
         os.makedirs(target_modules_dir)
 
+        local_modules_dir = os.path.join(os.path.dirname(self.descriptor),'cct')
+        self.log.debug('Found existing modules in directory: %s' % local_modules_dir)
+        if os.path.exists(local_modules_dir):
+            for module in os.listdir(local_modules_dir):
+                self.log.info('Using cached module %s.' % module)
+                shutil.copytree(os.path.join(local_modules_dir, module),
+                                os.path.join(target_modules_dir, module))
+
         cfg_file = os.path.join(cct_dir, "cct.yaml")
         with open(cfg_file, 'w') as f:
             yaml.dump(cfg['cct'], f)

--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -91,13 +91,13 @@ class CCT(Plugin):
 
         os.makedirs(target_modules_dir)
 
-        local_modules_dir = os.path.join(os.path.dirname(self.descriptor),'cct')
+        local_modules_dir = os.path.join(os.path.dirname(self.descriptor), 'cct')
         self.log.debug('Found existing modules in directory: %s' % local_modules_dir)
         if os.path.exists(local_modules_dir):
             for module in os.listdir(local_modules_dir):
-                self.log.info('Using cached module %s.' % module)
-                shutil.copytree(os.path.join(local_modules_dir, module),
-                                os.path.join(target_modules_dir, module))
+                module_path = os.path.join(local_modules_dir, module)
+                self.log.info("Using cached module '%s' from path '%s'" % (module, module_path))
+                shutil.copytree(module_path, os.path.join(target_modules_dir, module))
 
         cfg_file = os.path.join(cct_dir, "cct.yaml")
         with open(cfg_file, 'w') as f:


### PR DESCRIPTION
Dogen CCT plugin can now inject CCT modules from directory next to
image descriptor as follows:

if you have directory structure like:
```
image.yaml
cct/module1
cct/module2
```

Dogen CCT plugin will make module1 and modul2 available in target
directory for CCT to use them.

If cct/module1 is symbolink link its target directory gets copied (symlink
is followed).