### PR TITLE
Cleaning target directories 

### DIFF
--- a/dogen/cli.py
+++ b/dogen/cli.py
@@ -76,6 +76,7 @@ class Dogen(object):
 
         logger.debug("Running version %s", version)
         try:
+            tools.cleanup(self.args.target)
             copy_image_module_to_repository(
                 os.path.join(os.path.dirname(self.args.descriptor_path),
                              'modules'),

--- a/dogen/tools.py
+++ b/dogen/tools.py
@@ -112,3 +112,14 @@ def prepare_external_repositories(repo_files_dir, image_dir):
         added_repos.append(os.path.splitext(os.path.basename(f))[0])
 
     return added_repos
+
+
+def cleanup(target):
+    """ Prepates target/image directory to be regenerated."""
+    dirs_to_clean = [os.path.join(target, 'image', 'modules'),
+                     os.path.join(target, 'image', 'repos'),
+                     os.path.join(target, 'repo')]
+    for d in dirs_to_clean:
+        if os.path.exists(d):
+            logger.debug("Removing dirty directory: '%s'" % d)
+            shutil.rmtree(d)


### PR DESCRIPTION
Artifacts are kept because they take long too download.