### PR TITLE
Strip -tech-preview from name for component

### DIFF
--- a/dogen/plugins/dist_git.py
+++ b/dogen/plugins/dist_git.py
@@ -60,12 +60,6 @@ class DistGitPlugin(Plugin):
 
         cfg['name'] = tech_preview_name
 
-        r = re.search("(ce-\d+\.\d+(-openshift)?-\w+-\d+\.\d+)(-.*)", self.branch)
-
-        if r:
-            self.branch = "%s-tech-preview%s" % (r.group(1), r.group(3))
-            self.log.info("Generating tech-preview image, updating branch name to: %s" % self.branch)
-
     def after_sources(self, files):
         if not self.args.dist_git_enable:
             return

--- a/dogen/template_helper.py
+++ b/dogen/template_helper.py
@@ -25,10 +25,15 @@ class TemplateHelper(object):
 
     def component(self, name):
         """
-        Returns the vomponent name based on the image name
+        Returns the component name based on the image name
         """
 
-        return "%s" % re.sub(r'^(.*)/(.*)$', r'\1-\2-docker', name)
+        r = re.sub(r'^(.*)/(.*)$', r'\1-\2-docker', name)
+
+        # we don't want -tech-preview to be in component fields
+        r = r.replace("-tech-preview",'')
+
+        return "%s" % r
 
     def base_image(self, base_image, version):
         """

--- a/tests/test_unit_template_helper.py
+++ b/tests/test_unit_template_helper.py
@@ -16,6 +16,4 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.helper.component("jboss-eap-7-beta/eap70"), "jboss-eap-7-beta-eap70-docker")
     
     def test_generate_component_for_tech_preview_image(self):
-        self.assertEqual(self.helper.component("jboss-eap-7-tech-preview/eap70"), "jboss-eap-7-tech-preview-eap70-docker")
-
-
+        self.assertEqual(self.helper.component("jboss-eap-7-tech-preview/eap70"), "jboss-eap-7-eap70-docker")


### PR DESCRIPTION
For tech preview images, we do not want to influence the component
field name.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>